### PR TITLE
Hotfix Trailing slash

### DIFF
--- a/homeconnect/lib/src/models/settings/constraints/setting_constraints.dart
+++ b/homeconnect/lib/src/models/settings/constraints/setting_constraints.dart
@@ -18,7 +18,12 @@ class AllowedValuesPayload {
 
   AllowedValuesPayload(this.constraints);
   factory AllowedValuesPayload.fromJson(Map<String, dynamic> json) {
-    var allowedValues = json['data']['constraints']['allowedvalues'] as List;
+    var allowedValues = [];
+    try {
+      allowedValues = json['data']['constraints']['allowedvalues'] as List;
+    } catch (e) {
+      allowedValues = [];
+    }
     return AllowedValuesPayload(SettingsConstraints(allowedValues: allowedValues));
   }
 }

--- a/homeconnect/lib/src/utils/uri.dart
+++ b/homeconnect/lib/src/utils/uri.dart
@@ -2,6 +2,6 @@ import 'dart:core';
 
 extension JoinUri on Uri {
   Uri join(String path) {
-    return resolve(path);
+    return resolve(path.endsWith('/') ? path.substring(0, path.length - 1) : path);
   }
 }


### PR DESCRIPTION
# Fix more bugs
- remove trailing slash on uri
- return empty array if `allowedvalues` not present on json