### PR TITLE
Improve access token handling

### DIFF
--- a/homeconnect/lib/src/client/client_dart.dart
+++ b/homeconnect/lib/src/client/client_dart.dart
@@ -51,7 +51,10 @@ class HomeConnectApi {
       throw Exception('No authenticator provided');
     }
     final userCredentials = await storage.getCredentials();
-    final tokens = await authenticator?.refresh(baseUrl, userCredentials!.refreshToken);
+    if (userCredentials == null) {
+      throw Exception('Failed to refresh token');
+    }
+    final tokens = await authenticator?.refresh(baseUrl, userCredentials.refreshToken);
     if (tokens == null) {
       throw Exception('Failed to refresh token');
     }

--- a/homeconnect/lib/src/client/client_dart.dart
+++ b/homeconnect/lib/src/client/client_dart.dart
@@ -63,7 +63,7 @@ class HomeConnectApi {
   }
 
   Future<http.Response> put({required String resource, required String body}) async {
-    HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
+    await checkTokenIntegrity();
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.put(uri, headers: commonHeaders, body: body);
     if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -74,7 +74,7 @@ class HomeConnectApi {
   }
 
   Future<http.Response> get(String resource) async {
-    HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
+    await checkTokenIntegrity();
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.get(
       uri,
@@ -88,7 +88,7 @@ class HomeConnectApi {
   }
 
   Future<http.Response> delete(String resource) async {
-    HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
+    await checkTokenIntegrity();
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.delete(
       uri,
@@ -131,7 +131,7 @@ class HomeConnectApi {
 
   Future<void> openEventListenerChannel({required HomeDevice source}) async {
     final uri = baseUrl.join("/api/homeappliances/${source.info.haId}/events");
-    HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
+    await checkTokenIntegrity();
     EventController eventController = EventController();
 
     try {

--- a/homeconnect/lib/src/client/client_dart.dart
+++ b/homeconnect/lib/src/client/client_dart.dart
@@ -34,6 +34,7 @@ class HomeConnectApi {
       throw Exception('No authenticator provided');
     }
     final token = await authenticator!.authorize(baseUrl, credentials);
+    _accessToken = token.accessToken;
     storage.setCredentials(token);
   }
 
@@ -54,13 +55,12 @@ class HomeConnectApi {
     if (tokens == null) {
       throw Exception('Failed to refresh token');
     }
-    // set token in storage
+    _accessToken = tokens.accessToken;
     await storage.setCredentials(tokens);
   }
 
   Future<http.Response> put({required String resource, required String body}) async {
     HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
-    _accessToken = userCredentials!.accessToken;
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.put(uri, headers: commonHeaders, body: body);
     if (response.statusCode >= 200 && response.statusCode < 300) {
@@ -72,7 +72,6 @@ class HomeConnectApi {
 
   Future<http.Response> get(String resource) async {
     HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
-    _accessToken = userCredentials!.accessToken;
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.get(
       uri,
@@ -87,7 +86,6 @@ class HomeConnectApi {
 
   Future<http.Response> delete(String resource) async {
     HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
-    _accessToken = userCredentials!.accessToken;
     final uri = baseUrl.join('/api/homeappliances/$resource');
     final response = await client.delete(
       uri,
@@ -132,7 +130,6 @@ class HomeConnectApi {
     final uri = baseUrl.join("/api/homeappliances/${source.info.haId}/events");
     HomeConnectAuthCredentials? userCredentials = await checkTokenIntegrity();
     EventController eventController = EventController();
-    _accessToken = userCredentials!.accessToken;
 
     try {
       EventSource eventSource = await EventSource.connect(
@@ -170,6 +167,7 @@ class HomeConnectApi {
   }
 
   Future<void> logout() async {
+    _accessToken = '';
     await storage.clearCredentials();
   }
 }


### PR DESCRIPTION
I've noticed that the value of the access token is not be updated when `HomeConnectApi.logout()` is called. It also seems more straight-forward to update the value whenever the token is refreshed (i.e. during `authenticate()` and `refreshToken()`).